### PR TITLE
Add support for session tokens to aws provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 go.sum
 rattus
 /release/*
+.vscode/*
+.env

--- a/aws.go
+++ b/aws.go
@@ -7,25 +7,24 @@ import (
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
 )
 
-func createAWSSession(AWSRegion, AWSKeyID, AWSKeySecret string) (*session.Session, error) {
-	var awsCredentials *credentials.Credentials
-	var awsSession *session.Session
+// Used SDK https://github.com/aws/aws-sdk-go
 
-	if (AWSKeyID != "") && (AWSKeySecret != "") {
-		awsCredentials = credentials.NewStaticCredentials(AWSKeyID, AWSKeySecret, "")
+func createAWSSession(AWSRegion, AWSKeyID, AWSKeySecret, AWSSessionToken string) (*session.Session, error) {
+	if (AWSRegion != "") && (AWSKeyID != "") && (AWSKeySecret != "") {
+		return session.NewSession(&aws.Config{
+			Region:      aws.String(AWSRegion),
+			Credentials: credentials.NewStaticCredentials(AWSKeyID, AWSKeySecret, AWSSessionToken),
+		})
+	} else {
+		// Load creds from environment, shared credentials (~/.aws/credentials),
+		// or EC2 Instance Role.
+		return session.NewSession()
 	}
-
-	awsSession, err := session.NewSession(&aws.Config{
-		Region:      aws.String(AWSRegion),
-		Credentials: awsCredentials,
-	})
-
-	return awsSession, err
 }
 
-func getAWSSecretString(secretName, AWSRegion, AWSKeyID, AWSKeySecret string) (string, error) {
+func getAWSSecretString(secretName, AWSRegion, AWSKeyID, AWSKeySecret, AWSSessionToken string) (string, error) {
 	var secret string
-	awsSession, err := createAWSSession(AWSRegion, AWSKeyID, AWSKeySecret)
+	awsSession, err := createAWSSession(AWSRegion, AWSKeyID, AWSKeySecret, AWSSessionToken)
 	if err != nil {
 		return secret, err
 	}

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ type applicationConfig struct {
 	AWSRegion              string
 	AWSKeyID               string
 	AWSKeySecret           string
+	AWSSessionToken        string
 	AzureTenantID          string
 	AzureClientID          string
 	AzureClientSecret      string
@@ -31,19 +32,25 @@ func initializeConfiguration() applicationConfig {
 	c.AWSRegion = "us-east-1"
 
 	// cli arguments
+	argTemplatePath := flag.String("template", "", "Path to template file - /app/config/production.template\nenv: TEMPLATE_PATH\n")
+	c.Debug = flag.Bool("debug", false, "Enable debug information\n")
+
+	// Vault arguments
 	argVaultSecret := flag.String("vault-secret", "", "Vault secret URL - https://vault.example.io/v1/storage/secret\nenv: VAULT_SECRET\n")
 	argVaultToken := flag.String("vault-token", "", "Vault authentication token\nenv: VAULT_TOKEN")
+
+	// Aws arguments
 	argAWSSecretName := flag.String("aws-secret-name", "", "AWS secret name - example-project-backend\nenv: AWS_SECRET_NAME\n")
-	argAWSRegion := flag.String("aws-region", "", "AWS region - us-east-1\nenv: AWS_DEFAULT_REGION\n")
+	argAWSRegion := flag.String("aws-region", "", "AWS region - us-east-1\nenv: AWS_REGION\n")
 	argAWSKeyID := flag.String("aws-key-id", "", "AWS account ID\nenv: AWS_ACCESS_KEY_ID\n")
 	argAWSKeySecret := flag.String("aws-key-secret", "", "AWS account secret\nAWS_SECRET_ACCESS_KEY\n")
-	argTemplatePath := flag.String("template", "", "Path to template file - /app/config/production.template\nenv: TEMPLATE_PATH\n")
+	argAWSSessionToken := flag.String("aws-session-token", "", "AWS session token secret\nAWS_SESSION_TOKEN\n")
+
+	// Azure arguments
 	argAzureTenantID := flag.String("azure-tenant-id", "", "Azure tenant ID\nenv: AZURE_TENANT_ID\n")
 	argAzureClientID := flag.String("azure-client-id", "", "Azure client ID\nenv: AZURE_CLIENT_ID\n")
 	argAzureClientSecret := flag.String("azure-client-secret", "", "Azure client Secret\nenv: AZURE_CLIENT_SECRET\n")
 	argAzureVault := flag.String("azure-vault", "", "Azure keyvault storage URL - https://example-key-vault.vault.azure.net/\nenv: AZURE_VAULT\n")
-
-	c.Debug = flag.Bool("debug", false, "Enable debug information\n")
 
 	flag.Parse()
 
@@ -103,6 +110,15 @@ func initializeConfiguration() applicationConfig {
 	}
 	if *argAWSKeySecret != "" {
 		c.AWSKeySecret = *argAWSKeySecret
+	}
+
+	// aws session token
+	envAWSSessionToken := os.Getenv("AWS_SESSION_TOKEN")
+	if envAWSKeySecret != "" {
+		c.AWSSessionToken = envAWSSessionToken
+	}
+	if *argAWSKeySecret != "" {
+		c.AWSSessionToken = *argAWSSessionToken
 	}
 
 	envAzureTenantID := os.Getenv("AZURE_TENANT_ID")
@@ -171,7 +187,7 @@ func main() {
 		}
 
 	case "aws":
-		secrets, err = getAWSSecretString(config.AWSSecretName, config.AWSRegion, config.AWSKeyID, config.AWSKeySecret)
+		secrets, err = getAWSSecretString(config.AWSSecretName, config.AWSRegion, config.AWSKeyID, config.AWSKeySecret, config.AWSSessionToken)
 		if err != nil {
 			fmt.Printf("Error: %s\n", err)
 			os.Exit(1)

--- a/readme.md
+++ b/readme.md
@@ -61,6 +61,9 @@ Rattus supports configuration through flags or through environment variables. Th
   
 -aws-key-secret string
   env: AWS_SECRET_ACCESS_KEY
+
+-aws-session-token string
+  env: AWS_SESSION_TOKEN
   
 -aws-region string
   env: AWS_DEFAULT_REGION


### PR DESCRIPTION
Added support for temporary keys for AWS secrets provider(`AWS_SESSION_TOKEN`). To use needed aws profile set `AWS_PROFILE`.

Now rattus can be used locally like this 
This auth into was and get temp keys
```
saml2aws login --idp-account={idp_account}
```
Then export them as environment variables
```
eval $(saml2aws script --idp-account={idp_account})
```
And just call rattus
```
AWS_PROFILE=saml rattus -aws-secret-name={secret_name} -template={template} > {to}
```
In 0.2 version is not possible because we only send `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` and request to get secrets fails with 400 error.